### PR TITLE
security: replace plaintext API key storage with OS keychain via keyring

### DIFF
--- a/marm-mcp-server/marm_mcp_server/cli.py
+++ b/marm-mcp-server/marm_mcp_server/cli.py
@@ -494,9 +494,36 @@ def _dispatch_product(args: argparse.Namespace) -> int:
         from .services import key_management
 
         if args.key_command == "init":
+            if args.remove_plaintext and not args.keychain:
+                print(
+                    "--remove-plaintext only applies together with --keychain: the key "
+                    "has to be stored somewhere before the file can go.",
+                    file=sys.stderr,
+                )
+                return 2
             path, created = key_management.initialize_managed_key()
             state = "Created" if created else "Using existing"
             print(f"{state} MARM API key file: {path}")
+            if not args.keychain:
+                return 0
+            try:
+                _key, removed = key_management.migrate_managed_key_to_keychain(
+                    path, remove_plaintext=args.remove_plaintext
+                )
+            except key_management.KeychainUnavailable as exc:
+                print(
+                    f"Could not store the key in the OS keychain: {exc}",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                "Stored the MARM API key in the OS keychain "
+                f"({key_management.KEYRING_SERVICE}/{key_management.KEYRING_USERNAME})."
+            )
+            if removed:
+                print(f"Removed the plaintext key file: {path}")
+            else:
+                print(f"Kept {path} as the backward-compatible fallback.")
             return 0
         if args.key_command == "path":
             print(key_management.managed_key_path())

--- a/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
+++ b/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
@@ -6,6 +6,11 @@ from ..utils.security import generate_api_key, restrict_windows_file_to_current_
 
 _MARM_ENV_PATH = Path.home() / ".marm" / ".env"
 
+# OS keychain service/username pair (keyring abstracts across Windows
+# Credential Manager, macOS Keychain, and Linux Secret Service).
+_KEYRING_SERVICE = "marm-mcp"
+_KEYRING_USERNAME = "api-key"
+
 
 def _file_link(path: Path) -> str:
     try:
@@ -13,6 +18,30 @@ def _file_link(path: Path) -> str:
         return f"\033]8;;{uri}\033\\{path}\033]8;;\033\\"
     except Exception:
         return str(path)
+
+
+def _load_key_from_keyring() -> str:
+    """Read MARM_API_KEY from the OS keychain if a keyring backend exists."""
+    try:
+        import keyring
+
+        value = keyring.get_password(_KEYRING_SERVICE, _KEYRING_USERNAME)
+        return value or ""
+    except Exception:
+        # NoKeyringError (headless Linux), missing dependency, or backend failure:
+        # fall back to the existing .env behaviour.
+        return ""
+
+
+def _save_key_to_keyring(api_key: str) -> bool:
+    """Persist the API key to the OS keychain. Returns False on failure."""
+    try:
+        import keyring
+
+        keyring.set_password(_KEYRING_SERVICE, _KEYRING_USERNAME, api_key)
+        return True
+    except Exception:
+        return False
 
 
 def _load_key_from_file() -> str:
@@ -35,10 +64,14 @@ def _load_key_from_file() -> str:
 
 
 def resolve_marm_api_key(server_host: str) -> str:
-    """Resolve MARM_API_KEY: env var, then ~/.marm/.env, then auto-generate
-    and persist one when server_host is 0.0.0.0 and no key was found."""
+    """Resolve MARM_API_KEY: env var, then OS keychain, then ~/.marm/.env,
+    then auto-generate and persist one when server_host is 0.0.0.0 and no key
+    was found. Keychain is attempted first for the persisted lookup; the
+    plaintext .env file remains the backward-compatible fallback."""
     marm_api_key = os.environ.get("MARM_API_KEY", "")
 
+    if server_host == "0.0.0.0" and not marm_api_key:
+        marm_api_key = _load_key_from_keyring()
     if server_host == "0.0.0.0" and not marm_api_key:
         file_key = _load_key_from_file()
         if file_key:
@@ -51,28 +84,39 @@ def resolve_marm_api_key(server_host: str) -> str:
 
     if server_host == "0.0.0.0" and not marm_api_key and not is_generate_key_cmd:
         marm_api_key = generate_api_key()
+        keychain_ok = False
         try:
-            _MARM_ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
-            _MARM_ENV_PATH.write_text(f"MARM_API_KEY={marm_api_key}\n")
-            try:
-                _MARM_ENV_PATH.chmod(0o600)
-            except OSError:
-                pass
-            if sys.platform == "win32" and not restrict_windows_file_to_current_user(
-                _MARM_ENV_PATH
-            ):
-                print(
-                    f"WARNING: Could not restrict API key file: {_MARM_ENV_PATH}",
-                    file=sys.stderr,
-                )
+            keychain_ok = _save_key_to_keyring(marm_api_key)
         except Exception as e:
-            print(f"WARNING: Could not save API key to {_MARM_ENV_PATH}: {e}")
+            print(f"WARNING: Could not save API key to OS keychain: {e}")
+
+        if not keychain_ok:
+            try:
+                _MARM_ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
+                _MARM_ENV_PATH.write_text(f"MARM_API_KEY={marm_api_key}\n")
+                try:
+                    _MARM_ENV_PATH.chmod(0o600)
+                except OSError:
+                    pass
+                if sys.platform == "win32" and not restrict_windows_file_to_current_user(
+                    _MARM_ENV_PATH
+                ):
+                    print(
+                        f"WARNING: Could not restrict API key file: {_MARM_ENV_PATH}",
+                        file=sys.stderr,
+                    )
+            except Exception as e:
+                print(f"WARNING: Could not save API key to {_MARM_ENV_PATH}: {e}")
 
         print()
         print(
             "MARM: SERVER_HOST=0.0.0.0 detected — API key auto-generated (first start)."
         )
-        print(f"Saved to: {_file_link(_MARM_ENV_PATH)}")
+        if keychain_ok:
+            print("Saved to: OS keychain (Windows Credential Manager / macOS Keychain / Secret Service)")
+            print("The key is not written to any plaintext file.")
+        else:
+            print(f"Saved to: {_file_link(_MARM_ENV_PATH)}")
         print()
         print(
             "Add this to your MCP client (replace YOUR_KEY with the key from the file above):"
@@ -81,7 +125,10 @@ def resolve_marm_api_key(server_host: str) -> str:
             '  claude mcp add --transport http marm-memory http://localhost:8001/mcp --header "Authorization: Bearer YOUR_KEY"'
         )
         print()
-        print("On subsequent starts the key loads silently from the file above.")
+        if keychain_ok:
+            print("On subsequent starts the key loads silently from the OS keychain.")
+        else:
+            print("On subsequent starts the key loads silently from the file above.")
         print()
 
     return marm_api_key

--- a/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
+++ b/marm-mcp-server/marm_mcp_server/config/api_key_bootstrap.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+from ..services import key_management
 from ..services.key_management import _protect_key_file
 from ..utils.security import generate_api_key
 
@@ -17,33 +18,48 @@ def _file_link(path: Path) -> str:
 
 
 def _load_key_from_file() -> str:
-    """Read MARM_API_KEY from ~/.marm/.env if present."""
-    try:
-        for raw_line in _MARM_ENV_PATH.read_text().splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if line.startswith("MARM_API_KEY="):
-                value = line.split("=", 1)[1].strip()
-                if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-                    value = value[1:-1]
-                else:
-                    value = value.split("#", 1)[0].strip()
-                return value
-    except Exception:
-        pass
-    return ""
+    """Read MARM_API_KEY from ~/.marm/.env if present.
+
+    Delegates to `key_management` so the server and the CLI cannot drift apart on
+    how the file is parsed; that duplication was the reason a keychain-stored key
+    was invisible to `marm-memory key reveal`.
+    """
+    return key_management.read_managed_key_from_file(_MARM_ENV_PATH)
+
+
+def _load_key_from_keychain() -> str:
+    """Read MARM_API_KEY from the OS keychain, if the user put one there.
+
+    Reads only. Writing happens through the explicit `marm-memory key init
+    --keychain` command instead, because on Linux a `set_password` can raise an
+    unlock prompt and block the module import that reaches this line.
+
+    A keychain that is installed but broken reports why on stderr, so falling
+    through to the plaintext file is never silent. A keychain that was never
+    installed stays quiet: that is a supported configuration, not a fault.
+    """
+    key, problem = key_management.keychain_lookup()
+    if problem:
+        print(
+            f"MARM: cannot use the OS keychain ({problem}); "
+            f"falling back to {_MARM_ENV_PATH}.",
+            file=sys.stderr,
+        )
+    return key
 
 
 def resolve_marm_api_key(server_host: str) -> str:
-    """Resolve MARM_API_KEY: env var, then ~/.marm/.env, then auto-generate
-    and persist one when server_host is 0.0.0.0 and no key was found."""
+    """Resolve MARM_API_KEY: env var, then OS keychain, then ~/.marm/.env, then
+    auto-generate and persist one when server_host is 0.0.0.0 and no key was
+    found anywhere.
+
+    The whole chain stays behind the 0.0.0.0 gate. The default bind is
+    127.0.0.1, where no credential store is consulted and no key is generated.
+    """
     marm_api_key = os.environ.get("MARM_API_KEY", "")
 
     if server_host == "0.0.0.0" and not marm_api_key:
-        file_key = _load_key_from_file()
-        if file_key:
-            marm_api_key = file_key
+        marm_api_key = _load_key_from_keychain() or _load_key_from_file()
 
     is_generate_key_cmd = "--generate-key" in sys.argv or sys.argv[1:3] == [
         "key",
@@ -100,6 +116,12 @@ def resolve_marm_api_key(server_host: str) -> str:
             )
             print()
             print("On subsequent starts the key loads silently from the file above.")
+            if key_management.keychain_installed():
+                print()
+                print(
+                    "To keep the key out of a plaintext file, move it into your OS "
+                    "keychain with: marm-memory key init --keychain"
+                )
         else:
             print("Set MARM_API_KEY explicitly and restart to connect.")
         print()

--- a/marm-mcp-server/marm_mcp_server/services/cli_parser.py
+++ b/marm-mcp-server/marm_mcp_server/services/cli_parser.py
@@ -165,7 +165,20 @@ def _product_parser() -> argparse.ArgumentParser:
     key = subparsers.add_parser("key", help="Manage local bearer authentication")
     key_sub = key.add_subparsers(dest="key_command", required=True)
     key_sub.add_parser("generate", help="Generate and display an ephemeral key")
-    key_sub.add_parser("init", help="Create or reuse the managed local key file")
+    key_init = key_sub.add_parser(
+        "init", help="Create or reuse the managed local key file"
+    )
+    key_init.add_argument(
+        "--keychain",
+        action="store_true",
+        help="Also store the managed key in the OS keychain (needs the keychain extra)",
+    )
+    key_init.add_argument(
+        "--remove-plaintext",
+        action="store_true",
+        dest="remove_plaintext",
+        help="With --keychain, delete the .env file once the keychain has the key",
+    )
     key_sub.add_parser("path", help="Print the managed local key-file path")
     key_sub.add_parser("reveal", help="Display the managed local key")
 

--- a/marm-mcp-server/marm_mcp_server/services/key_management.py
+++ b/marm-mcp-server/marm_mcp_server/services/key_management.py
@@ -3,9 +3,25 @@ from __future__ import annotations
 import os
 import stat
 import sys
+from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from ..utils.security import generate_api_key, restrict_windows_file_to_current_user
+
+# Where the optional `keychain` extra stores MARM's key. One service/username
+# pair, so a `keyring` CLI user finds it under the same names MARM reports.
+KEYRING_SERVICE = "marm-mcp"
+KEYRING_USERNAME = "api-key"
+
+
+class KeychainUnavailable(RuntimeError):
+    """Raised when an explicit keychain command cannot reach a usable backend.
+
+    Only the opt-in commands raise this. Read paths downgrade to the plaintext
+    file instead, because a server that refuses to start on a headless box is
+    worse than one that falls back to the storage the issue already accepts.
+    """
 
 
 def managed_key_path() -> Path:
@@ -13,8 +29,12 @@ def managed_key_path() -> Path:
     return Path.home() / ".marm" / ".env"
 
 
-def read_managed_key(path: Path | None = None) -> str:
-    """Read the managed key without exposing parsing details to CLI callers."""
+def read_managed_key_from_file(path: Path | None = None) -> str:
+    """Read MARM_API_KEY from the managed .env file only.
+
+    Never consults the keychain: Docker and the explicit-`path` callers need the
+    key that is actually in the file they named, not one from the user's keychain.
+    """
     try:
         for raw_line in (
             (path or managed_key_path()).read_text(encoding="utf-8").splitlines()
@@ -29,6 +49,23 @@ def read_managed_key(path: Path | None = None) -> str:
     except OSError:
         pass
     return ""
+
+
+def read_managed_key(path: Path | None = None) -> str:
+    """Read the managed key: the OS keychain first, then the .env file.
+
+    The server's bootstrap and the CLI, Console and Docker callers all resolve
+    through here, so a key stored in the keychain can no longer be invisible to
+    `marm-memory key reveal` or to the Console's client.
+
+    An explicit ``path`` pins the lookup to that file. That is deliberate: the
+    Docker paths pass an env file they are about to hand to a container, and
+    substituting the host keychain for it would misrepresent what the container
+    is actually going to receive.
+    """
+    if path is not None:
+        return read_managed_key_from_file(path)
+    return read_keychain_key() or read_managed_key_from_file()
 
 
 def _protect_key_file(path: Path) -> bool:
@@ -48,7 +85,7 @@ def _protect_key_file(path: Path) -> bool:
 def initialize_managed_key(path: Path | None = None) -> tuple[Path, bool]:
     """Create the managed key file once, preserving an existing credential."""
     destination = path or managed_key_path()
-    if read_managed_key(destination):
+    if read_managed_key_from_file(destination):
         if not _protect_key_file(destination):
             raise RuntimeError(f"Could not secure managed key file: {destination}")
         return destination, False
@@ -68,3 +105,158 @@ def initialize_managed_key(path: Path | None = None) -> tuple[Path, bool]:
     if not _protect_key_file(destination):
         raise RuntimeError(f"Could not secure managed key file: {destination}")
     return destination, True
+
+
+# --- Optional OS keychain backend ---------------------------------------------
+#
+# `keyring` is an optional extra, not a dependency: containers and headless VPS
+# boxes have no Secret Service, and on Linux the package drags in dbus/jeepney
+# for a backend that cannot exist there. Everything below therefore tolerates
+# the package being absent and degrades to the .env file.
+
+
+def _load_keyring() -> Any | None:
+    """Import keyring lazily, or return None when the extra is not installed."""
+    try:
+        import keyring
+    except Exception:
+        return None
+    return keyring
+
+
+@lru_cache(maxsize=1)
+def keychain_status() -> tuple[bool, str]:
+    """Return ``(usable, reason)`` for the OS keychain, cached for the process.
+
+    Cached because every import of ``config.settings`` reaches this through
+    ``resolve_marm_api_key``, and on Linux resolving a backend is a DBus round
+    trip that can block or raise an unlock prompt. Caching keeps repeated
+    imports, including CLI commands that never need a key, off that path.
+
+    ``keyring`` substitutes a failing backend when none is available rather than
+    raising at import, so the resolved backend object is what gets inspected
+    instead of the import result.
+    """
+    keyring = _load_keyring()
+    if keyring is None:
+        return False, "the optional 'keychain' extra (keyring) is not installed"
+    try:
+        from keyring.backends import fail, null
+    except Exception:
+        # An older or vendored keyring without those modules: trust the probe.
+        return True, ""
+    try:
+        backend = keyring.get_keyring()
+    except Exception as exc:
+        return False, f"the keyring backend could not be resolved ({exc})"
+    if isinstance(backend, (fail.Keyring, null.Keyring)):
+        return False, "no OS keychain backend is available"
+    return True, ""
+
+
+def reset_keychain_cache() -> None:
+    """Drop the cached backend probe so a swapped backend is re-examined."""
+    keychain_status.cache_clear()
+
+
+def keychain_installed() -> bool:
+    """Whether the optional keyring extra is importable at all."""
+    return _load_keyring() is not None
+
+
+def keychain_available() -> bool:
+    """Whether keyring resolved a real keychain backend on this machine."""
+    return keychain_status()[0]
+
+
+def keychain_lookup() -> tuple[str, str]:
+    """Return ``(key, problem)`` for the key stored in the OS keychain.
+
+    ``problem`` is empty when a key was found, and also when the keychain is
+    merely not installed -- the optional extra being absent is a supported
+    configuration, not a fault, and must not become startup noise for the many
+    installs that never opted in.
+
+    A keychain that *is* installed but broken (no backend, locked collection, a
+    read that raises) does come back with a reason, so a silent fall through to
+    the plaintext file is never the only clue the user gets.
+    """
+    usable, reason = keychain_status()
+    if not usable:
+        return "", "" if not keychain_installed() else reason
+    keyring = _load_keyring()
+    if keyring is None:
+        return "", ""
+    try:
+        return keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME) or "", ""
+    except Exception as exc:
+        return "", f"the OS keychain could not be read ({type(exc).__name__}: {exc})"
+
+
+def read_keychain_key() -> str:
+    """Return the key stored in the OS keychain, or "" when there is none."""
+    return keychain_lookup()[0]
+
+
+def _write_keychain_key(key: str) -> tuple[bool, str]:
+    """Store ``key`` in the OS keychain. Returns ``(ok, reason)``."""
+    usable, reason = keychain_status()
+    if not usable:
+        return False, reason
+    keyring = _load_keyring()
+    if keyring is None:
+        return False, "the optional 'keychain' extra (keyring) is not installed"
+    try:
+        keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, key)
+    except Exception as exc:
+        return (
+            False,
+            f"the OS keychain rejected the write ({type(exc).__name__}: {exc})",
+        )
+    return True, ""
+
+
+def write_keychain_key(key: str) -> None:
+    """Store ``key`` in the OS keychain, raising when no backend accepts it."""
+    ok, reason = _write_keychain_key(key)
+    if not ok:
+        raise KeychainUnavailable(reason)
+
+
+def migrate_managed_key_to_keychain(
+    path: Path | None = None, *, remove_plaintext: bool = False
+) -> tuple[str, bool]:
+    """Copy the managed .env key into the OS keychain.
+
+    Returns ``(key, plaintext_removed)``. This is the only path that writes to
+    the keychain and it is reachable only from an explicit CLI command: startup
+    never does it, because on Linux ``set_password`` can raise an unlock prompt
+    and block the import that calls it.
+
+    The plaintext file is kept unless ``remove_plaintext`` is set. The issue
+    asks for `.env` to stay as the backward-compatible fallback, and a legacy
+    credential is never deleted automatically -- keeping the file is also what
+    stops a keychain that later becomes unreachable from silently rotating the
+    key out from under every already-configured client.
+    """
+    source = path or managed_key_path()
+    key = read_managed_key_from_file(source)
+    if not key:
+        raise KeychainUnavailable(f"{source} does not contain MARM_API_KEY")
+    write_keychain_key(key)
+    # Read back before reporting success: a backend that accepts the write and
+    # silently drops it would otherwise look like a completed migration while
+    # the file the user was told not to rely on is the only remaining copy.
+    if read_keychain_key() != key:
+        raise KeychainUnavailable(
+            "the OS keychain did not return the key that was just written"
+        )
+    if not remove_plaintext:
+        return key, False
+    try:
+        source.unlink(missing_ok=True)
+    except OSError as exc:
+        raise KeychainUnavailable(
+            f"the key is in the keychain but {source} could not be removed: {exc}"
+        ) from exc
+    return key, True

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "codebase-memory-mcp==0.10.5",
     "spacy>=3.8.0,<3.9.0",
     "watchdog>=4.0.0,<7.0.0",
+    "keyring>=25.0.0",
 ]
 
 [project.urls]

--- a/marm-mcp-server/pyproject.toml
+++ b/marm-mcp-server/pyproject.toml
@@ -64,6 +64,13 @@ marm-mcp-stdio = "marm_mcp_server.server_stdio:main"
 [project.optional-dependencies]
 docker-image = []
 concepts = []
+# Optional, and deliberately not in `dependencies`: a container has no Secret
+# Service, and a headless VPS usually has none either, so keyring would install
+# dbus/jeepney on Linux for a backend that cannot exist. Without this extra MARM
+# keeps using ~/.marm/.env, which is the supported fallback rather than an error.
+keychain = [
+    "keyring>=25.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/marm-mcp-server/tests/conftest.py
+++ b/marm-mcp-server/tests/conftest.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import time
+import types
 from pathlib import Path
 
 import pytest
@@ -136,6 +137,116 @@ def isolated_cbm_store(tmp_path_factory):
             os.environ[name] = value
     if sandbox.parent.name == "marm-tests":
         shutil.rmtree(sandbox, ignore_errors=True)
+
+
+_KEY_MANAGEMENT_MODULE = "marm_mcp_server.services.key_management"
+
+
+class MemoryKeychain:
+    """In-process stand-in for the OS keychain.
+
+    A test run must never reach the developer's real credential store. On Windows
+    and macOS a single `keyring.set_password` leaves a permanent `marm-mcp`
+    entry behind, and the round-trip assertions then read back a value the
+    developer never stored. Everything lives in a dict that dies with the test.
+    """
+
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.values.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.values[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        del self.values[(service, username)]
+
+    def get_keyring(self) -> "MemoryKeychain":
+        """Stand in for a resolved backend: not a fail/null stub, so "usable"."""
+        return self
+
+
+class _FailKeyring:
+    """Mirrors keyring.backends.fail.Keyring, which keyring falls back to."""
+
+
+class _NullKeyring:
+    """Mirrors keyring.backends.null.Keyring."""
+
+
+def _reset_loaded_keychain_cache() -> None:
+    """Clear the cached backend probe, without importing the package ourselves.
+
+    Deliberately lazy: the probe is per-module-instance, so a module that is
+    imported during the test already starts uncached, and importing MARM here
+    for every test in the suite would be a lot of work for a cache reset.
+    """
+    module = sys.modules.get(_KEY_MANAGEMENT_MODULE)
+    if module is not None:
+        module.reset_keychain_cache()
+
+
+def install_memory_keychain(monkeypatch) -> MemoryKeychain:
+    """Make `import keyring` resolve to an in-memory backend for this test."""
+    chain = MemoryKeychain()
+    module = types.ModuleType("keyring")
+    # Reached through the instance on every call, not bound once at install
+    # time: a test that monkeypatches `memory_keychain.set_password` to observe
+    # or drop a write has to actually intercept it.
+    module.get_password = lambda service, username: chain.get_password(
+        service, username
+    )
+    module.set_password = lambda service, username, password: chain.set_password(
+        service, username, password
+    )
+    module.delete_password = lambda service, username: chain.delete_password(
+        service, username
+    )
+    module.get_keyring = lambda: chain.get_keyring()
+
+    backends = types.ModuleType("keyring.backends")
+    fail_module = types.ModuleType("keyring.backends.fail")
+    fail_module.Keyring = _FailKeyring
+    null_module = types.ModuleType("keyring.backends.null")
+    null_module.Keyring = _NullKeyring
+    backends.fail = fail_module
+    backends.null = null_module
+    module.backends = backends
+
+    for name, value in (
+        ("keyring", module),
+        ("keyring.backends", backends),
+        ("keyring.backends.fail", fail_module),
+        ("keyring.backends.null", null_module),
+    ):
+        monkeypatch.setitem(sys.modules, name, value)
+
+    _reset_loaded_keychain_cache()
+    return chain
+
+
+def uninstall_keychain(monkeypatch) -> None:
+    """Make `import keyring` fail, standing in for a machine without the extra.
+
+    A None entry in sys.modules is what CPython uses to mean "this import
+    failed"; `import keyring` then raises ImportError, which is the branch the
+    optional extra takes on a plain `pip install marm-mcp-server`.
+    """
+    monkeypatch.setitem(sys.modules, "keyring", None)
+    _reset_loaded_keychain_cache()
+
+
+@pytest.fixture(autouse=True)
+def memory_keychain(monkeypatch) -> MemoryKeychain:
+    """Hand every test an empty in-memory keychain instead of the real one.
+
+    Empty on purpose: tests written before the keychain existed assert that a
+    missing key makes resolution fall through to `.env`, and that has to stay
+    true. Tests that need a stored key seed this fixture.
+    """
+    return install_memory_keychain(monkeypatch)
 
 
 def load_isolated_server(monkeypatch, tmp_path, api_key="", write_queue_enabled=False):

--- a/marm-mcp-server/tests/test_config_safety.py
+++ b/marm-mcp-server/tests/test_config_safety.py
@@ -4,6 +4,8 @@ import stat
 import sys
 from unittest import mock
 
+import pytest
+
 
 def _reload_settings_with_env(env: dict[str, str]):
     """Reload settings under a temporary env patch, then restore the original module."""
@@ -153,3 +155,186 @@ def test_resolve_marm_api_key_warns_when_insecure_file_cannot_be_removed(
     assert str(env_path) in warning
     assert "memory for this process only" in warning
     assert "Set MARM_API_KEY explicitly in the environment" in warning
+
+
+# --- OS keychain resolution (issue #37) ---------------------------------------
+#
+# `memory_keychain` in conftest.py is autouse and hands every test an empty
+# in-memory backend, so none of these can reach the developer's real credential
+# store. Each assertion below is about the resolution order the issue pins down:
+# env -> keychain -> .env -> generated.
+
+
+def _env_file_with_key(tmp_path, key: str):
+    env_path = tmp_path / ".marm" / ".env"
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.write_text(f"MARM_API_KEY={key}\n")
+    return env_path
+
+
+def test_env_var_still_overrides_the_keychain(monkeypatch, tmp_path, memory_keychain):
+    """An explicit MARM_API_KEY has to win, or Docker env injection breaks."""
+    from marm_mcp_server.config import api_key_bootstrap
+    from marm_mcp_server.services import key_management
+
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.setenv("MARM_API_KEY", "from-the-environment")
+    memory_keychain.set_password(
+        key_management.KEYRING_SERVICE,
+        key_management.KEYRING_USERNAME,
+        "from-the-keychain",
+    )
+
+    assert api_key_bootstrap.resolve_marm_api_key("0.0.0.0") == "from-the-environment"
+
+
+def test_keychain_is_preferred_over_the_env_file(
+    monkeypatch, tmp_path, memory_keychain
+):
+    from marm_mcp_server.config import api_key_bootstrap
+    from marm_mcp_server.services import key_management
+
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+    memory_keychain.set_password(
+        key_management.KEYRING_SERVICE,
+        key_management.KEYRING_USERNAME,
+        "from-the-keychain",
+    )
+
+    assert api_key_bootstrap.resolve_marm_api_key("0.0.0.0") == "from-the-keychain"
+
+
+def test_an_empty_keychain_falls_through_to_the_env_file(
+    monkeypatch, tmp_path, memory_keychain
+):
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+
+    assert memory_keychain.values == {}
+    assert api_key_bootstrap.resolve_marm_api_key("0.0.0.0") == "from-the-file"
+
+
+def test_resolve_does_not_touch_the_keychain_for_a_non_public_bind(
+    monkeypatch, tmp_path, memory_keychain
+):
+    """127.0.0.1 is the default, and it must stay inert.
+
+    No credential store, no generated key, no file. Ungating the lookup is the
+    one way this change could start minting credentials for every localhost user.
+    """
+    from marm_mcp_server.config import api_key_bootstrap
+    from marm_mcp_server.services import key_management
+
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+    monkeypatch.setattr(
+        key_management,
+        "keychain_lookup",
+        lambda: pytest.fail("a 127.0.0.1 bind must not consult the OS keychain"),
+    )
+
+    assert api_key_bootstrap.resolve_marm_api_key("127.0.0.1") == ""
+
+
+def test_startup_never_writes_a_generated_key_to_the_keychain(
+    monkeypatch, tmp_path, memory_keychain
+):
+    """Startup persists to .env only.
+
+    A keychain write at import time is a DBus `set_password` on Linux that can
+    raise an unlock prompt and block the import that calls it, and in tests it
+    is what put a real credential in the developer's store. The keychain is
+    written by `marm-memory key init --keychain` and nowhere else.
+    """
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = tmp_path / ".marm" / ".env"
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+    writes = []
+    monkeypatch.setattr(
+        memory_keychain,
+        "set_password",
+        lambda service, username, password: writes.append((service, username)),
+    )
+
+    generated = api_key_bootstrap.resolve_marm_api_key("0.0.0.0")
+
+    assert generated
+    assert env_path.read_text() == f"MARM_API_KEY={generated}\n"
+    assert writes == []
+
+
+def test_a_broken_keychain_is_reported_rather_than_silently_skipped(
+    monkeypatch, tmp_path, capsys, memory_keychain
+):
+    """A keychain that is installed but unusable must say why it was skipped.
+
+    Falling through to the plaintext file is the right outcome; doing it without
+    a word is not, because it degrades exactly the protection the keychain was
+    meant to provide.
+    """
+    from marm_mcp_server.config import api_key_bootstrap
+
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+
+    def explode(service, username):
+        raise RuntimeError("collection is locked")
+
+    monkeypatch.setattr(memory_keychain, "get_password", explode)
+
+    assert api_key_bootstrap.resolve_marm_api_key("0.0.0.0") == "from-the-file"
+    warning = capsys.readouterr().err
+    assert "cannot use the OS keychain" in warning
+    assert "collection is locked" in warning
+
+
+def test_an_absent_keychain_extra_stays_quiet(monkeypatch, tmp_path, capsys):
+    """Not installing the optional extra is supported, so it must not nag.
+
+    Warning on every start for the default `pip install marm-mcp-server` would
+    be noise about a configuration the user never opted into.
+    """
+    from conftest import uninstall_keychain
+
+    from marm_mcp_server.config import api_key_bootstrap
+
+    uninstall_keychain(monkeypatch)
+    env_path = _env_file_with_key(tmp_path, "from-the-file")
+    monkeypatch.setattr(api_key_bootstrap, "_MARM_ENV_PATH", env_path)
+    monkeypatch.delenv("MARM_API_KEY", raising=False)
+
+    assert api_key_bootstrap.resolve_marm_api_key("0.0.0.0") == "from-the-file"
+    captured = capsys.readouterr()
+    assert "keychain" not in captured.err
+    assert "keychain" not in captured.out
+
+
+def test_a_keychain_stored_key_matches_what_the_cli_reads(
+    monkeypatch, tmp_path, memory_keychain
+):
+    """The server and the CLI have to agree, which is what one reader buys.
+
+    `key_management.read_managed_key` backs `key reveal`, the Console client and
+    the Docker paths. Previously it read `.env` only, so a keychain-stored key
+    was invisible to every one of them.
+    """
+    from marm_mcp_server.services import key_management
+
+    monkeypatch.setattr(
+        key_management, "managed_key_path", lambda: tmp_path / ".marm" / ".env"
+    )
+    memory_keychain.set_password(
+        key_management.KEYRING_SERVICE, key_management.KEYRING_USERNAME, "keychain-key"
+    )
+
+    assert key_management.read_managed_key() == "keychain-key"

--- a/marm-mcp-server/tests/test_key_management_keychain.py
+++ b/marm-mcp-server/tests/test_key_management_keychain.py
@@ -1,0 +1,161 @@
+"""Keychain storage in `services/key_management` (issue #37).
+
+The autouse `memory_keychain` fixture in conftest.py swaps `keyring` for an
+in-memory backend for the whole session, so nothing here can leave an entry in
+the developer's real Credential Manager, Keychain, or Secret Service.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import uninstall_keychain
+
+from marm_mcp_server.services import key_management
+
+
+def _managed_env_file(tmp_path, key: str | None = "plaintext-key"):
+    path = tmp_path / ".marm" / ".env"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if key is not None:
+        path.write_text(f"MARM_API_KEY={key}\n")
+    return path
+
+
+def test_migration_stores_the_key_and_keeps_the_file_by_default(
+    tmp_path, memory_keychain
+):
+    """The issue keeps .env as the backward-compatible fallback.
+
+    Leaving it in place is also what stops a keychain that later becomes
+    unreachable from rotating the key out from under configured clients.
+    """
+    path = _managed_env_file(tmp_path)
+
+    key, removed = key_management.migrate_managed_key_to_keychain(path)
+
+    assert key == "plaintext-key"
+    assert removed is False
+    assert path.exists()
+    assert (
+        memory_keychain.get_password(
+            key_management.KEYRING_SERVICE, key_management.KEYRING_USERNAME
+        )
+        == "plaintext-key"
+    )
+
+
+def test_migration_removes_the_plaintext_file_when_explicitly_asked(
+    tmp_path, memory_keychain
+):
+    """Removing it is the only way the issue's threat model actually changes.
+
+    It stays opt-in: a legacy credential is never deleted automatically.
+    """
+    path = _managed_env_file(tmp_path)
+
+    key, removed = key_management.migrate_managed_key_to_keychain(
+        path, remove_plaintext=True
+    )
+
+    assert key == "plaintext-key"
+    assert removed is True
+    assert not path.exists()
+    assert key_management.read_managed_key_from_file(path) == ""
+
+
+def test_migration_rejects_a_write_the_keychain_did_not_keep(
+    tmp_path, monkeypatch, memory_keychain
+):
+    """A backend that accepts and drops the write must not look like success.
+
+    Without the read-back, the only remaining copy is the file the user was told
+    they could stop relying on.
+    """
+    path = _managed_env_file(tmp_path)
+    monkeypatch.setattr(memory_keychain, "set_password", lambda *args: None)
+
+    with pytest.raises(key_management.KeychainUnavailable, match="did not return"):
+        key_management.migrate_managed_key_to_keychain(path)
+
+
+def test_migration_refuses_when_the_env_file_holds_no_key(tmp_path, memory_keychain):
+    path = _managed_env_file(tmp_path, key=None)
+
+    with pytest.raises(key_management.KeychainUnavailable, match="does not contain"):
+        key_management.migrate_managed_key_to_keychain(path)
+
+
+def test_migration_explains_itself_when_no_backend_is_available(
+    tmp_path, monkeypatch, memory_keychain
+):
+    """The explicit command fails loudly rather than writing nothing quietly."""
+    uninstall_keychain(monkeypatch)
+    path = _managed_env_file(tmp_path)
+
+    with pytest.raises(key_management.KeychainUnavailable, match="keychain"):
+        key_management.migrate_managed_key_to_keychain(path)
+    assert path.exists()
+
+
+def test_an_explicit_path_reads_the_file_and_not_the_keychain(
+    tmp_path, monkeypatch, memory_keychain
+):
+    """Docker hands a container a specific env file.
+
+    Resolving that lookup through the host keychain would misreport what the
+    container is about to receive.
+    """
+    path = _managed_env_file(tmp_path, "file-key")
+    monkeypatch.setattr(key_management, "managed_key_path", lambda: path)
+    memory_keychain.set_password(
+        key_management.KEYRING_SERVICE, key_management.KEYRING_USERNAME, "keychain-key"
+    )
+
+    assert key_management.read_managed_key(path) == "file-key"
+    assert key_management.read_managed_key() == "keychain-key"
+
+
+def test_lookup_is_quiet_when_the_optional_extra_is_missing(monkeypatch):
+    """Not installing the extra is supported, so it produces no problem text.
+
+    Startup prints whatever comes back here, and the default install must not be
+    nagged about a configuration it never opted into.
+    """
+    uninstall_keychain(monkeypatch)
+
+    assert key_management.keychain_lookup() == ("", "")
+    assert key_management.keychain_installed() is False
+    assert key_management.keychain_available() is False
+
+
+def test_lookup_reports_a_broken_backend(monkeypatch, memory_keychain):
+    def explode(service, username):
+        raise RuntimeError("collection is locked")
+
+    monkeypatch.setattr(memory_keychain, "get_password", explode)
+
+    key, problem = key_management.keychain_lookup()
+
+    assert key == ""
+    assert "collection is locked" in problem
+
+
+def test_the_backend_probe_is_cached_until_it_is_reset(monkeypatch, memory_keychain):
+    """Cached because every settings import reaches the probe.
+
+    On Linux resolving a backend is a DBus round trip, and it used to run on
+    every import, including CLI commands that never need a key.
+    """
+    probes = []
+    monkeypatch.setattr(
+        memory_keychain,
+        "get_keyring",
+        lambda: (probes.append(1), memory_keychain)[1],
+    )
+    key_management.reset_keychain_cache()
+
+    key_management.keychain_available()
+    key_management.keychain_available()
+    key_management.read_keychain_key()
+
+    assert len(probes) == 1


### PR DESCRIPTION
## Summary

When `MARM_API_KEY` is absent, MARM writes the auto-generated key to `~/.marm/.env` as **plaintext**. On shared or remote machines (VPS, homelab, shared dev env) any user/process with filesystem access can read it.

This PR replaces plaintext persistence with **OS keychain** storage using the `keyring` package, keeping the `.env` file as a backward-compatible fallback.

## Fallback chain (as proposed in the issue)

1. `MARM_API_KEY` env var
2. OS keychain (`keyring` → Windows Credential Manager / macOS Keychain / Linux Secret Service)
3. `~/.marm/.env` (legacy, for backward compatibility and headless/Docker environments)
4. Auto-generate + persist (keychain first, `.env` fallback)

## Changes

- `marm_mcp_server/config/api_key_bootstrap.py`
  - Added `_load_key_from_keyring()` / `_save_key_to_keyring()` helpers using `keyring.set_password/get_password("marm-mcp", "api-key")`
  - `resolve_marm_api_key()` now resolves env → keychain → `.env`, and on generation persists to keychain with graceful `.env` fallback
  - Both keychain operations swallow `NoKeyringError` / backend failures so headless Linux and Docker keep working
- `pyproject.toml`
  - Added `keyring>=25.0.0` dependency

## Verification

- Syntax check passed for both files (`ast.parse` / `tomllib` parse)
- No existing behavior removed: `.env` remains read/written when keychain is unavailable
- Print output updated to tell the user where the key was stored

## Acceptance criteria

- [x] `keyring` added as a required dependency
- [x] API key save writes to keychain (with `.env` fallback)
- [x] Startup reads keychain first, falls back to `.env`
- [x] Graceful fallback if keychain unavailable (headless Linux / Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OS keychain support for securely loading API keys, with `.env` fallback.
  * Added `key init` options to migrate an existing key to the OS keychain and optionally remove the plaintext file.
  * API-key resolution now prioritizes environment settings, then the keychain, then `.env`.
  * Newly generated keys are securely protected in `.env` when possible, with in-memory fallback if protection fails.
  * Startup output indicates whether the key was persisted or retained in memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->