### PR TITLE
test(docker): exposed mode authenticates, and MARM's managed Docker path never reaches the keyless fallback (#170 item 5)

### DIFF
--- a/marm-mcp-server/tests/test_docker_transports.py
+++ b/marm-mcp-server/tests/test_docker_transports.py
@@ -15,6 +15,18 @@ pytestmark = pytest.mark.docker
 
 DOCKER_IMAGE = os.environ.get("MARM_DOCKER_IMAGE", "lyellr88/marm-mcp-server:latest")
 
+# Every probe below talks to a container this file just started, so an ambient
+# proxy must never be consulted. With HTTP_PROXY set and no_proxy unset,
+# requests sends these calls to the proxy and the assertions then describe the
+# proxy rather than the container: a stub proxy that answers /health 200, an
+# unauthenticated call 401 and a keyed call 200 makes
+# test_docker_exposed_publish_still_requires_key_off_loopback pass with nothing
+# listening on the published port at all. Loopback is not exempt either -
+# requests.utils.should_bypass_proxies("http://127.0.0.1:<port>/health", None)
+# is False under those settings - so the session is the file's, not one test's.
+HTTP = requests.Session()
+HTTP.trust_env = False
+
 
 def _run_docker(args, timeout=60):
     return subprocess.run(
@@ -52,7 +64,7 @@ def _wait_for_health(base_url, timeout=90):
     last_error = None
     while time.time() < deadline:
         try:
-            response = requests.get(f"{base_url}/health", timeout=3)
+            response = HTTP.get(f"{base_url}/health", timeout=3)
             if response.status_code == 200 and response.json()["status"] == "healthy":
                 return
         except Exception as exc:
@@ -110,11 +122,11 @@ def test_docker_http_requires_key_and_serves_tools(docker_image, marm_data_dir):
     try:
         _wait_for_health(base_url)
 
-        ready = requests.get(f"{base_url}/ready", timeout=5)
+        ready = HTTP.get(f"{base_url}/ready", timeout=5)
         assert ready.status_code == 200
         assert "websocket" not in ready.text.lower()
 
-        openapi = requests.get(f"{base_url}/openapi.json", timeout=5)
+        openapi = HTTP.get(f"{base_url}/openapi.json", timeout=5)
         assert openapi.status_code == 200
         operation_ids = {
             operation.get("operationId")
@@ -124,16 +136,16 @@ def test_docker_http_requires_key_and_serves_tools(docker_image, marm_data_dir):
         }
         assert set(MCP_TOOL_OPERATIONS).issubset(operation_ids)
 
-        missing_auth = requests.get(
+        missing_auth = HTTP.get(
             f"{base_url}/marm_log_show", params={"session_name": "main"}, timeout=5
         )
-        wrong_auth = requests.get(
+        wrong_auth = HTTP.get(
             f"{base_url}/marm_log_show",
             params={"session_name": "main"},
             headers={"Authorization": "Bearer wrong"},
             timeout=5,
         )
-        correct_auth = requests.get(
+        correct_auth = HTTP.get(
             f"{base_url}/marm_log_show",
             params={"session_name": "main"},
             headers={"Authorization": f"Bearer {api_key}"},
@@ -144,7 +156,7 @@ def test_docker_http_requires_key_and_serves_tools(docker_image, marm_data_dir):
         assert wrong_auth.status_code == 401
         assert correct_auth.status_code == 200
 
-        no_websocket = requests.get(
+        no_websocket = HTTP.get(
             f"{base_url}/mcp/ws",
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=5,
@@ -455,7 +467,7 @@ def test_docker_data_persists_across_container_restart(docker_image, marm_data_d
 
     try:
         base_url = _start(first_container)
-        write = requests.post(
+        write = HTTP.post(
             f"{base_url}/marm_log_entry",
             json={
                 "entry": f"2026-07-07-persist-check-wrote from {first_container}",
@@ -470,7 +482,7 @@ def test_docker_data_persists_across_container_restart(docker_image, marm_data_d
 
     try:
         base_url = _start(second_container)
-        read = requests.get(
+        read = HTTP.get(
             f"{base_url}/marm_log_show",
             params={"session_name": session_name},
             headers=headers,
@@ -631,13 +643,13 @@ def test_docker_exposed_publish_still_requires_key_off_loopback(
         _wait_for_health(f"http://127.0.0.1:{port}")
         remote = f"http://{host_ip}:{port}"
 
-        health = requests.get(f"{remote}/health", timeout=5)
+        health = HTTP.get(f"{remote}/health", timeout=5)
         assert health.status_code == 200, "exposed port unreachable off loopback"
 
-        missing_auth = requests.get(
+        missing_auth = HTTP.get(
             f"{remote}/marm_log_show", params={"session_name": "main"}, timeout=5
         )
-        correct_auth = requests.get(
+        correct_auth = HTTP.get(
             f"{remote}/marm_log_show",
             params={"session_name": "main"},
             headers={"Authorization": f"Bearer {api_key}"},
@@ -688,7 +700,7 @@ def test_docker_without_a_key_generates_one_instead_of_loopback_fallback(
     try:
         _wait_for_health(base_url)
 
-        unauthenticated = requests.get(
+        unauthenticated = HTTP.get(
             f"{base_url}/marm_log_show", params={"session_name": "main"}, timeout=5
         )
         assert unauthenticated.status_code == 401
@@ -699,7 +711,7 @@ def test_docker_without_a_key_generates_one_instead_of_loopback_fallback(
         generated = _read_generated_key(container)
         assert generated, "no key was persisted to the mounted data dir"
 
-        authenticated = requests.get(
+        authenticated = HTTP.get(
             f"{base_url}/marm_log_show",
             params={"session_name": "main"},
             headers={"Authorization": f"Bearer {generated}"},

--- a/marm-mcp-server/tests/test_docker_transports.py
+++ b/marm-mcp-server/tests/test_docker_transports.py
@@ -696,7 +696,7 @@ def test_docker_without_a_key_generates_one_instead_of_loopback_fallback(
         # (auth.py:47), the loopback fallback (auth.py:26-36) sends none.
         assert unauthenticated.headers.get("WWW-Authenticate") == "Bearer"
 
-        generated = _read_generated_key(marm_data_dir / ".env")
+        generated = _read_generated_key(container)
         assert generated, "no key was persisted to the mounted data dir"
 
         authenticated = requests.get(
@@ -710,11 +710,20 @@ def test_docker_without_a_key_generates_one_instead_of_loopback_fallback(
         _run_docker(["rm", "-f", container], timeout=30)
 
 
-def _read_generated_key(env_path):
-    """MARM_API_KEY out of the .env the container wrote into the bind mount."""
-    if not env_path.exists():
+def _read_generated_key(container):
+    """MARM_API_KEY out of the .env the container wrote, read from inside it.
+
+    The file lands in the bind mount, but api_key_bootstrap.py:60 chmods it to
+    0600 and the container's non-root marm user owns it, so on a Linux host the
+    obvious read from the mount is a PermissionError rather than a key. Measured
+    on a runner: the host-side version of this failed exactly that way.
+    """
+    result = _run_docker(
+        ["exec", container, "cat", "/home/marm/.marm/.env"], timeout=20
+    )
+    if result.returncode != 0:
         return ""
-    for line in env_path.read_text().splitlines():
+    for line in result.stdout.splitlines():
         if line.strip().startswith("MARM_API_KEY="):
             return line.split("=", 1)[1].strip()
     return ""

--- a/marm-mcp-server/tests/test_docker_transports.py
+++ b/marm-mcp-server/tests/test_docker_transports.py
@@ -566,3 +566,155 @@ def test_docker_stdio_tool_count_matches_http_registered_tools(
     assert 2 in responses, f"No tools/list response; stderr: {stderr_text}"
     tool_names = {t["name"] for t in responses[2]["result"]["tools"]}
     assert tool_names == set(MCP_TOOL_OPERATIONS)
+
+
+def _non_loopback_ipv4():
+    """The host's own address on its default route, or "" if it has none.
+
+    `--expose-network` publishes on 0.0.0.0 instead of 127.0.0.1, and the only
+    thing that distinguishes the two is whether a client arriving on a real
+    interface is served. Reaching the port over this address is what makes the
+    exposed test different from every other test in this file, which all talk
+    to 127.0.0.1. UDP connect() sends nothing; it only asks the kernel which
+    source address it would use.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        try:
+            sock.connect(("192.0.2.1", 9))  # TEST-NET-1, never routed anywhere
+        except OSError:
+            return ""
+        address = sock.getsockname()[0]
+    return "" if address.startswith("127.") else address
+
+
+def test_docker_exposed_publish_still_requires_key_off_loopback(
+    docker_image, marm_data_dir
+):
+    """Exposed mode must authenticate the clients that only it can reach.
+
+    test_docker_http_requires_key_and_serves_tools proves auth over a
+    127.0.0.1-published port, which is the binding `--expose-network` exists to
+    change (services/docker_commands.py:126). test_docker_commands.py:74 checks
+    that the flag reaches the argv. Neither reaches a running container over a
+    non-loopback interface, so nothing yet proves that the mode which accepts
+    off-host clients rejects the unauthenticated ones.
+    """
+    host_ip = _non_loopback_ipv4()
+    if not host_ip:
+        pytest.skip("Host has no non-loopback IPv4 address to publish on")
+
+    container = f"marm-test-exposed-{uuid.uuid4().hex[:10]}"
+    port = _free_port()
+    api_key = "TestExposedKey_67890#abcDEF"
+
+    run = _run_docker(
+        [
+            "run",
+            "-d",
+            "--name",
+            container,
+            "-p",
+            f"0.0.0.0:{port}:8001",
+            "-e",
+            "SERVER_HOST=0.0.0.0",
+            "-e",
+            f"MARM_API_KEY={api_key}",
+            "-v",
+            f"{marm_data_dir}:/home/marm/.marm",
+            docker_image,
+        ],
+        timeout=90,
+    )
+    assert run.returncode == 0, run.stderr
+
+    try:
+        _wait_for_health(f"http://127.0.0.1:{port}")
+        remote = f"http://{host_ip}:{port}"
+
+        health = requests.get(f"{remote}/health", timeout=5)
+        assert health.status_code == 200, "exposed port unreachable off loopback"
+
+        missing_auth = requests.get(
+            f"{remote}/marm_log_show", params={"session_name": "main"}, timeout=5
+        )
+        correct_auth = requests.get(
+            f"{remote}/marm_log_show",
+            params={"session_name": "main"},
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=5,
+        )
+
+        assert missing_auth.status_code == 401
+        assert correct_auth.status_code == 200
+    finally:
+        _run_docker(["rm", "-f", container], timeout=30)
+
+
+def test_docker_without_a_key_generates_one_instead_of_loopback_fallback(
+    docker_image, marm_data_dir
+):
+    """A container started with no key is key-enforced, not loopback-trusting.
+
+    middleware/auth.py:16 documents a keyless mode that serves 127.0.0.1 and
+    401s everyone else. Docker never reaches it: the run plan always sets
+    SERVER_HOST=0.0.0.0 (services/docker_commands.py:143), and at that host
+    config/api_key_bootstrap.py:53-54 generates and persists a key when none
+    was supplied, so MARM_API_KEY is always truthy inside the image. The
+    documented fallback is unreachable here, and this pins that, because the
+    difference is invisible from outside until you ask which 401 you got.
+    """
+    container = f"marm-test-nokey-{uuid.uuid4().hex[:10]}"
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    run = _run_docker(
+        [
+            "run",
+            "-d",
+            "--name",
+            container,
+            "-p",
+            f"127.0.0.1:{port}:8001",
+            "-e",
+            "SERVER_HOST=0.0.0.0",
+            "-v",
+            f"{marm_data_dir}:/home/marm/.marm",
+            docker_image,
+        ],
+        timeout=90,
+    )
+    assert run.returncode == 0, run.stderr
+
+    try:
+        _wait_for_health(base_url)
+
+        unauthenticated = requests.get(
+            f"{base_url}/marm_log_show", params={"session_name": "main"}, timeout=5
+        )
+        assert unauthenticated.status_code == 401
+        # The two 401s differ only here: the key branch sends a challenge
+        # (auth.py:47), the loopback fallback (auth.py:26-36) sends none.
+        assert unauthenticated.headers.get("WWW-Authenticate") == "Bearer"
+
+        generated = _read_generated_key(marm_data_dir / ".env")
+        assert generated, "no key was persisted to the mounted data dir"
+
+        authenticated = requests.get(
+            f"{base_url}/marm_log_show",
+            params={"session_name": "main"},
+            headers={"Authorization": f"Bearer {generated}"},
+            timeout=5,
+        )
+        assert authenticated.status_code == 200
+    finally:
+        _run_docker(["rm", "-f", container], timeout=30)
+
+
+def _read_generated_key(env_path):
+    """MARM_API_KEY out of the .env the container wrote into the bind mount."""
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text().splitlines():
+        if line.strip().startswith("MARM_API_KEY="):
+            return line.split("=", 1)[1].strip()
+    return ""


### PR DESCRIPTION
I am an AI agent (Claude), writing as Anton's synthetic cofounder under his review.

Took item 5's `--expose-network` bullet only: **"nothing verifies that exposed mode actually enforces auth while loopback behaves as documented."** Items 2, 3 and 4 stay untouched and unclaimed by me, and so do the other remaining bullets of item 5 (upgrade path, bind-mount uid mismatch).

Two tests, no production change. The first half of the bullet held. The second half turned out not to be true in Docker at all.

### "exposed mode actually enforces auth"

It does, and now something says so. `--expose-network`'s only effect is the published host binding, `0.0.0.0` instead of `127.0.0.1` (`services/docker_commands.py:126`). `test_docker_commands.py:74` checks that the flag reaches the argv, and `test_docker_http_requires_key_and_serves_tools` checks auth against a `127.0.0.1`-published container, which is the binding the flag exists to change. Nothing reached a running container over the interface that only exposed mode opens.

The new test publishes on `0.0.0.0` and then talks to the container over the host's own routable address rather than loopback, so it exercises the path the flag is for: `/health` reachable, unauthenticated `/marm_log_show` 401, keyed 200.

### "while loopback behaves as documented"

In Docker it cannot behave that way. `middleware/auth.py:16` documents a keyless mode that serves `127.0.0.1` and 401s everyone else. But `build_run_plan` always passes `-e SERVER_HOST=0.0.0.0` (`docker_commands.py:143`), and at that host `resolve_marm_api_key` generates and persists a key when none was supplied (`config/api_key_bootstrap.py:53-54`). `MARM_API_KEY` is therefore always truthy inside the image, and the fallback at `auth.py:23-37` is unreachable in a container.

That is the safe direction and I am not proposing to change it. It is simply unpinned: nothing today would notice if it stopped being true, and from outside the two 401s are indistinguishable. The test tells them apart by `WWW-Authenticate`, which only the key branch sends (`auth.py:47`), then reads the generated key back out of the container and uses it.

### Evidence, from real containers rather than reading

| run | result |
|---|---|
| [change](https://github.com/tonydzi/marm-memory/actions/runs/33738089408) | 12 passed |
| [mutation A](https://github.com/tonydzi/marm-memory/actions/runs/33737688637): bearer-key requirement dropped | both new tests red, `assert 200 == 401` |
| [mutation B](https://github.com/tonydzi/marm-memory/actions/runs/33737692124): key auto-generation removed | `assert None == 'Bearer'` |

Mutation B is the one that proves the second half above: removing the auto-generation is the only way to make `auth.py:23-37` reachable in a container, and when it becomes reachable the test says so immediately.

### Two calls that are yours, not mine

1. Whether the no-key test belongs in this PR at all. It pins a behavior nobody wrote down as a promise, and you may prefer the docstring at `auth.py:14-18` corrected instead, since it describes a mode Docker users can never be in. I did not touch that docstring.
2. I appended to `test_docker_transports.py` rather than adding a file, because the container fixtures and helpers already live there and your note said to follow its pattern. Say the word if you would rather have a separate module.

### One I got wrong

The first run read the generated `.env` straight from the bind mount and got `PermissionError`: `api_key_bootstrap.py:60` chmods it to `0600` under the container's `marm` uid, so the host user cannot read it. That run was [11 passed, 1 failed](https://github.com/tonydzi/marm-memory/actions/runs/33737629306), with the other three assertions of that test already green. It now reads via `docker exec`. That failure is a live instance of the uid-mismatch bullet still open in item 5, which I have not claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Docker integration coverage to confirm that unauthenticated requests over published non-loopback interfaces are rejected with an authentication challenge.
  * Added coverage verifying that containers without a configured access key generate and persist one.
  * Added checks for successful authenticated requests using generated or configured keys.
  * Improved platform-specific handling so unsupported environments skip incompatible network checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->